### PR TITLE
ADHOC: Add localhost origin

### DIFF
--- a/StoriesApi/Program.cs
+++ b/StoriesApi/Program.cs
@@ -26,10 +26,10 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
-var allowedOrigins = app.Configuration.GetSection("appSettings") != null
-            ? app.Configuration.GetSection("appSettings").GetSection("AllowedCorsOrigins").GetChildren().Select(x => x.Value).ToArray()
+var allowedOrigins = app.Configuration.GetSection("AllowedCorsOrigins") != null
+            ? app.Configuration.GetSection("AllowedCorsOrigins").GetChildren().Select(x => x.Value).ToArray()
             : Array.Empty<string>();
-        Trace.WriteLine("allowed origins:" + string.Join(',', allowedOrigins));
+        Console.WriteLine("allowed origins:" + string.Join(',', allowedOrigins));
         app.UseCors(x => x
             .WithOrigins(allowedOrigins)
             .AllowAnyMethod()

--- a/StoriesApi/appsettings.json
+++ b/StoriesApi/appsettings.json
@@ -8,5 +8,9 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "Default": "Server=stories-database.c1wa8gg6cizv.us-east-2.rds.amazonaws.com,3306;Database=storiesDB;user=admin;password=1l1k32Wr1t3!"
-  }
+  },
+  "AllowedCorsOrigins": [
+    "http://localhost:3000"
+  ]
+  
 }


### PR DESCRIPTION
Adds "localhost:3000" to the list of allowed origins so we should be able to access it while running the frontend locally.