### PR TITLE
53: Username taken

### DIFF
--- a/StoriesApi/Controllers/UsersController.cs
+++ b/StoriesApi/Controllers/UsersController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using StoriesApi.Models;
+using StoriesApi.Utils;
 
 namespace StoriesApi.Controllers
 {
@@ -67,6 +68,12 @@ namespace StoriesApi.Controllers
         [HttpPost]
         public async Task<ActionResult<User>> UserUser(User user)
         {
+            // does username already exist?
+            if (_context.Users.Any(existingUser => existingUser.Username == user.Username))
+            {
+                return StatusCode(StatusCodes.Status400BadRequest, new { message = nameof(ErrorCode.UsernameTaken) });
+            }
+
             _context.Users.Add(user);
 
             await _context.SaveChangesAsync();

--- a/StoriesApi/Utils/ErrorCode.cs
+++ b/StoriesApi/Utils/ErrorCode.cs
@@ -1,0 +1,6 @@
+namespace StoriesApi.Utils;
+
+public enum ErrorCode
+{
+    UsernameTaken
+}


### PR DESCRIPTION
Adds a custom error code for a username already being taken when someone is trying to sign up. This can then be caught on the frontend so that we can more specifically catch this case and respond to the user appropriately. We also can add more error codes as needed.

<img width="1181" height="376" alt="Screenshot 2025-07-21 at 18 07 13" src="https://github.com/user-attachments/assets/cd83ec1b-c2da-40a7-b29a-2ac1505d9594" />
