### PR TITLE
47: Multiget endpoint

### DIFF
--- a/StoriesApi/Controllers/UsersController.cs
+++ b/StoriesApi/Controllers/UsersController.cs
@@ -8,6 +8,9 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using StoriesApi.Models;
 using StoriesApi.Utils;
+using StoriesApi.Models.Requests;
+using StoriesApi.Models.Responses;
+using StoriesApi.Models;
 
 namespace StoriesApi.Controllers
 {
@@ -34,6 +37,19 @@ namespace StoriesApi.Controllers
             }
 
             return user;
+        }
+
+        // Get multiple users at once
+        [HttpPost("multiget")]
+        public async Task<MultigetUserResponse> MultigetUser(MultigetRequest request)
+        {
+            var users = await _context.Users.Where(user => request.Ids.Contains(user.UserId)).ToListAsync();
+            var userDict = users.ToDictionary(x => x.UserId);
+
+            return new MultigetUserResponse
+            {
+                Users = userDict
+            };
         }
 
         // Login user - api/Users/login

--- a/StoriesApi/Models/Requests/LoginRequest.cs
+++ b/StoriesApi/Models/Requests/LoginRequest.cs
@@ -1,4 +1,4 @@
-namespace StoriesApi.Models;
+namespace StoriesApi.Models.Requests;
 
 public class LoginRequest
 {

--- a/StoriesApi/Models/Requests/MultigetRequest.cs
+++ b/StoriesApi/Models/Requests/MultigetRequest.cs
@@ -1,0 +1,7 @@
+namespace StoriesApi.Models.Requests;
+
+public class MultigetRequest
+{
+    public required List<int> Ids { get; set; }
+
+}

--- a/StoriesApi/Models/Responses/MultigetUserResponse.cs
+++ b/StoriesApi/Models/Responses/MultigetUserResponse.cs
@@ -1,0 +1,9 @@
+using StoriesApi.Models;
+
+namespace StoriesApi.Models.Responses;
+
+public class MultigetUserResponse
+{
+    public required Dictionary<int, User> Users { get; set; }
+
+}

--- a/StoriesApi/resources.txt
+++ b/StoriesApi/resources.txt
@@ -1,2 +1,5 @@
 Tutorial: Create a web API with ASP.NET core: 
 https://learn.microsoft.com/en-us/aspnet/core/tutorials/first-web-api?view=aspnetcore-9.0&tabs=visual-studio-code 
+
+run backend:
+dotnet run --launch-profile https


### PR DESCRIPTION
Adds an operation that allows you to get multiple users by passing in an array of ids. Returns a dictionary mapping each id to a User. If a User is not found, that id is simply not returned in the dictionary.

<img width="1246" height="588" alt="Screenshot 2025-08-31 at 13 22 56" src="https://github.com/user-attachments/assets/19aba77b-9bf3-45ab-8dbc-91af2a2ceb16" />
