### PR TITLE
65: Get posts error

### DIFF
--- a/StoriesApi/Models/Post.cs
+++ b/StoriesApi/Models/Post.cs
@@ -4,7 +4,7 @@ public class Post
 {
     public int PostId { get; private set; }
     public required string Content { get; set; }
-    public required string Author { get; set; }
+    public required int UserId { get; set; }
     public required DateTime Date { get; set; }
     public required int StoryId { get; set; }
 }


### PR DESCRIPTION
Was getting a backend error when trying to fetch any posts. This is because we had 'author' as a field in our backend where it was 'userid' in the sql database. Changed to match our sql version.